### PR TITLE
array_key_exists instead of silenced error in ValidatorLocator

### DIFF
--- a/src/ValidatorLocator/ValidatorLocator.php
+++ b/src/ValidatorLocator/ValidatorLocator.php
@@ -27,7 +27,7 @@ class ValidatorLocator
      */
     public function getValidatorClass(string $name): Validator
     {
-        if (!($validator = @$this->cache[$name])) {
+        if (!array_key_exists($name, $this->cache)) {
             if (!($validator = $this->locate($name))) {
                 if (!($validator = $this->locateDefault($name))) {
                     throw new \Exception("Missed validator: " . $name);


### PR DESCRIPTION
Looking up in cache array by silencing php notice (on index not found) works like intended, however may, in some circumstances (Symfony and its SilencedErrorContext for example), cause some headache, filling log with

> php.DEBUG: Notice: Undefined index: string
> php.DEBUG: Notice: Undefined index: any
> php.DEBUG: Notice: Undefined index: bool

and so on upon every new request.

Little change proposed here, shouldn't change anything in behaviour, but will get rid of all these notices